### PR TITLE
update USER_AGENT to reflect latest changes as of January 11, 2026

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -5,6 +5,7 @@ pub static SEC_CH_UA_PLATFORM: &str = r#""Windows""#;
 pub static SEC_FETCH_SITE: &str = "none";
 pub static SEC_FETCH_MODE: &str = "cors";
 pub static SEC_FETCH_DEST: &str = "empty";
-pub static USER_AGENT:&str="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Edg/120.0.0.0";
+// Updated USER_AGENT to reflect the latest changes as of January 11, 2026.
+pub static USER_AGENT:&str="Mozilla/5.0 (Linux; Android 10; HD1913) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.7499.193 Mobile Safari/537.36 EdgA/143.0.3650.125";
 pub static WSS_URL:&str="wss://speech.platform.bing.com/consumer/speech/synthesize/readaloud/edge/v1?TrustedClientToken=6A5AA1D4EAFF4E9FB37E23D68491D6F4&ConnectionId=";
 pub static ORIGIN: &str = "chrome-extension://jdiccldimpdaibmpdkjnbmckianbfold";


### PR DESCRIPTION
Updated USER_AGENT to reflect the latest changes as of January 11, 2026.
File: src/constants.rs
```Rust
pub static USER_AGENT:&str="Mozilla/5.0 (Linux; Android 10; HD1913) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.7499.193 Mobile Safari/537.36 EdgA/143.0.3650.125";
```