### PR TITLE
refactor: Use reqwest library instead of isahc library (fixes #10)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target
+.idea/
 .vscode/
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,27 +12,54 @@ exclude = ["examples/*"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[[example]]
+name = "get_voices_list"
+required-features = ["blocking"]
+
+[[example]]
+name = "get_voices_list_proxy"
+required-features = ["blocking"]
+
+[[example]]
+name = "play"
+required-features = ["blocking"]
+
+[[example]]
+name = "synthesize"
+required-features = ["blocking"]
+
+[[example]]
+name = "synthesize_proxy"
+required-features = ["blocking"]
+
+[[example]]
+name = "synthesize_stream"
+required-features = ["blocking"]
+
+[[example]]
+name = "synthesize_stream_proxy"
+required-features = ["blocking"]
+
+[features]
+blocking = ["reqwest/blocking"]
 
 [dependencies]
-async-io = "2.6.0"
 async-lock = "3.4.2"
-async-native-tls = "0.5.0"
-async-std = "1.13.2"
-async-tungstenite = { version = "0.32.1", features = ["async-native-tls"] }
 base64 = "0.22.1"
 chrono = "0.4.43"
 futures-util = "0.3.31"
 http = "1.4.0"
 httparse = "1.10.1"
-isahc = { version = "1.7.2", features = ["json"] }
-native-tls = "0.2.14"
+reqwest = { version = "0.13.1",default-features = false,features = ["http2", "json", "native-tls"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 sha2 = "0.10.9"
 thiserror = "2.0.18"
-tungstenite = { version = "0.28.0", features = ["native-tls"] }
+tokio = { version = "1.49.0",features = ["io-std", "net"] }
+tokio-native-tls = "0.3.1"
+tokio-tungstenite = { version = "0.28.0", features = ["native-tls"] }
 uuid = { version = "1.19.0", features = ["fast-rng", "v4"] }
 
 [dev-dependencies]
-smol = "2.0.2"
 rodio = "0.21.1"
+tokio = {version = "1.49.0", features = ["macros", "rt-multi-thread"]}

--- a/examples/get_voices_list_async.rs
+++ b/examples/get_voices_list_async.rs
@@ -1,11 +1,10 @@
 use msedge_tts::voice::get_voices_list_async;
 use std::time::Instant;
 
-fn main() {
-    smol::block_on(async {
-        let start = Instant::now();
-        let voices = get_voices_list_async().await.unwrap();
-        println!("{:#?}", voices);
-        println!("{:?}", Instant::now() - start);
-    });
+#[tokio::main]
+async fn main() {
+    let start = Instant::now();
+    let voices = get_voices_list_async().await.unwrap();
+    println!("{:#?}", voices);
+    println!("{:?}", Instant::now() - start);
 }

--- a/examples/get_voices_list_proxy.rs
+++ b/examples/get_voices_list_proxy.rs
@@ -2,16 +2,14 @@ use msedge_tts::voice::get_voices_list_proxy;
 
 fn main() {
     // socks4 proxy
-    let voices =
-        get_voices_list_proxy("socks4a://localhost:10808".parse().unwrap(), None, None).unwrap();
+    let voices = get_voices_list_proxy("socks4a://localhost:10808", None, None).unwrap();
     println!("{:#?}", voices);
 
     // socks5 proxy
-    let voices =
-        get_voices_list_proxy("socks5h://localhost:10808".parse().unwrap(), None, None).unwrap();
+    let voices = get_voices_list_proxy("socks5h://localhost:10808", None, None).unwrap();
     println!("{:#?}", voices);
 
     // http proxy
-    let voices = get_voices_list_proxy("localhost:10809".parse().unwrap(), None, None).unwrap();
+    let voices = get_voices_list_proxy("localhost:10809", None, None).unwrap();
     println!("{:#?}", voices);
 }

--- a/examples/synthesize.rs
+++ b/examples/synthesize.rs
@@ -1,5 +1,5 @@
 use msedge_tts::{
-    tts::{client::connect, SpeechConfig},
+    tts::{SpeechConfig, client::connect},
     voice::get_voices_list,
 };
 use std::time::Instant;

--- a/examples/synthesize_async.rs
+++ b/examples/synthesize_async.rs
@@ -1,27 +1,26 @@
 use msedge_tts::{
-    tts::{client::connect_async, SpeechConfig},
+    tts::{SpeechConfig, client::connect_async},
     voice::get_voices_list_async,
 };
 use std::time::Instant;
 
-fn main() {
-    smol::block_on(async {
-        println!("get voices list...");
-        let voices = get_voices_list_async().await.unwrap();
-        for voice in &voices {
-            if voice.name.contains("YunyangNeural") {
-                println!("choose '{}' to synthesize...", voice.name);
-                let config = SpeechConfig::from(voice);
-                let mut tts = connect_async().await.unwrap();
-                let start = Instant::now();
-                let audio = tts
-                    .synthesize("Hello, World! 你好，世界！", &config)
-                    .await
-                    .unwrap();
-                println!("{:?}", audio.audio_metadata);
-                println!("{:?}", Instant::now() - start);
-                break;
-            }
+#[tokio::main]
+async fn main() {
+    println!("get voices list...");
+    let voices = get_voices_list_async().await.unwrap();
+    for voice in &voices {
+        if voice.name.contains("YunyangNeural") {
+            println!("choose '{}' to synthesize...", voice.name);
+            let config = SpeechConfig::from(voice);
+            let mut tts = connect_async().await.unwrap();
+            let start = Instant::now();
+            let audio = tts
+                .synthesize("Hello, World! 你好，世界！", &config)
+                .await
+                .unwrap();
+            println!("{:?}", audio.audio_metadata);
+            println!("{:?}", Instant::now() - start);
+            break;
         }
-    });
+    }
 }

--- a/examples/synthesize_proxy_async.rs
+++ b/examples/synthesize_proxy_async.rs
@@ -1,41 +1,40 @@
-use futures_util::{AsyncRead, AsyncWrite};
-use msedge_tts::{
-    tts::{
-        client::{connect_proxy_async, MSEdgeTTSClientAsync},
-        SpeechConfig,
+use {
+    msedge_tts::{
+        tts::{
+            SpeechConfig,
+            client::{MSEdgeTTSClientAsync, connect_proxy_async},
+        },
+        voice::get_voices_list_async,
     },
-    voice::get_voices_list_async,
+    std::time::Instant,
+    tokio::io::{AsyncRead, AsyncWrite},
 };
-use std::time::Instant;
 
-fn main() {
-    smol::block_on(async {
-        println!("get voices list...");
-        let voices = get_voices_list_async().await.unwrap();
-        for voice in &voices {
-            if voice.name.contains("YunyangNeural") {
-                println!("choose '{}' to synthesize...", voice.name);
-                let config = SpeechConfig::from(voice);
-                let tts = connect_proxy_async("localhost:10809".parse().unwrap(), None, None)
-                    .await
-                    .unwrap();
-                synthesize(tts, &config).await;
+#[tokio::main]
+async fn main() {
+    println!("get voices list...");
+    let voices = get_voices_list_async().await.unwrap();
+    for voice in &voices {
+        if voice.name.contains("YunyangNeural") {
+            println!("choose '{}' to synthesize...", voice.name);
+            let config = SpeechConfig::from(voice);
+            let tts = connect_proxy_async("localhost:10809".parse().unwrap(), None, None)
+                .await
+                .unwrap();
+            synthesize(tts, &config).await;
 
-                let tts =
-                    connect_proxy_async("socks4a://localhost:10808".parse().unwrap(), None, None)
-                        .await
-                        .unwrap();
-                synthesize(tts, &config).await;
+            let tts = connect_proxy_async("socks4a://localhost:10808".parse().unwrap(), None, None)
+                .await
+                .unwrap();
+            synthesize(tts, &config).await;
 
-                let tts =
-                    connect_proxy_async("socks5h://localhost:10808".parse().unwrap(), None, None)
-                        .await
-                        .unwrap();
-                synthesize(tts, &config).await;
-                break;
-            }
+            let tts = connect_proxy_async("socks5h://localhost:10808".parse().unwrap(), None, None)
+                .await
+                .unwrap();
+            synthesize(tts, &config).await;
+            break;
         }
-    });
+    }
 }
 
 async fn synthesize<T: AsyncRead + AsyncWrite + Unpin>(

--- a/examples/synthesize_stream.rs
+++ b/examples/synthesize_stream.rs
@@ -1,12 +1,14 @@
 use msedge_tts::{
-    tts::stream::{msedge_tts_split, SynthesizedResponse},
-    tts::SpeechConfig,
+    tts::{
+        SpeechConfig,
+        stream::{SynthesizedResponse, msedge_tts_split},
+    },
     voice::get_voices_list,
 };
 use std::{
     sync::{
-        atomic::{AtomicBool, Ordering},
         Arc,
+        atomic::{AtomicBool, Ordering},
     },
     thread::spawn,
     time::Instant,

--- a/examples/synthesize_stream_async.rs
+++ b/examples/synthesize_stream_async.rs
@@ -1,76 +1,76 @@
-use msedge_tts::{
-    tts::{
-        stream::{msedge_tts_split_async, SynthesizedResponse},
-        SpeechConfig,
+use {
+    msedge_tts::{
+        tts::{
+            SpeechConfig,
+            stream::{SynthesizedResponse, msedge_tts_split_async},
+        },
+        voice::get_voices_list_async,
     },
-    voice::get_voices_list_async,
-};
-use std::{
-    sync::{
-        atomic::{AtomicBool, Ordering},
-        Arc,
+    std::{
+        sync::{
+            Arc,
+            atomic::{AtomicBool, Ordering},
+        },
+        time::Instant,
     },
-    time::Instant,
 };
 
-fn main() {
-    smol::block_on(async {
-        println!("get voices list...");
-        let voices = get_voices_list_async().await.unwrap();
-        for voice in &voices {
-            if voice.name.contains("YunyangNeural") {
-                println!("choose '{}' to synthesize...", voice.name);
-                let config = SpeechConfig::from(voice);
-                let (mut sender, mut reader) = msedge_tts_split_async().await.unwrap();
+#[tokio::main]
+async fn main() {
+    println!("get voices list...");
+    let voices = get_voices_list_async().await.unwrap();
+    for voice in &voices {
+        if voice.name.contains("YunyangNeural") {
+            println!("choose '{}' to synthesize...", voice.name);
+            let config = SpeechConfig::from(voice);
+            let (mut sender, mut reader) = msedge_tts_split_async().await.unwrap();
 
-                let signal = Arc::new(AtomicBool::new(false));
-                let end = signal.clone();
-                let start = Instant::now();
-                smol::spawn(async move {
-                    sender
-                        .send("Hello, World! 你好，世界！", &config)
-                        .await
-                        .unwrap();
-                    println!("synthesizing...1");
-                    sender
-                        .send("Hello, World! 你好，世界！", &config)
-                        .await
-                        .unwrap();
-                    println!("synthesizing...2");
-                    sender
-                        .send("Hello, World! 你好，世界！", &config)
-                        .await
-                        .unwrap();
-                    println!("synthesizing...3");
-                    sender
-                        .send("Hello, World! 你好，世界！", &config)
-                        .await
-                        .unwrap();
-                    println!("synthesizing...4");
-                    end.store(true, Ordering::Relaxed);
-                })
-                .detach();
+            let signal = Arc::new(AtomicBool::new(false));
+            let end = signal.clone();
+            let start = Instant::now();
+            tokio::spawn(async move {
+                sender
+                    .send("Hello, World! 你好，世界！", &config)
+                    .await
+                    .unwrap();
+                println!("synthesizing...1");
+                sender
+                    .send("Hello, World! 你好，世界！", &config)
+                    .await
+                    .unwrap();
+                println!("synthesizing...2");
+                sender
+                    .send("Hello, World! 你好，世界！", &config)
+                    .await
+                    .unwrap();
+                println!("synthesizing...3");
+                sender
+                    .send("Hello, World! 你好，世界！", &config)
+                    .await
+                    .unwrap();
+                println!("synthesizing...4");
+                end.store(true, Ordering::Relaxed);
+            });
 
-                loop {
-                    if signal.load(Ordering::Relaxed) && !reader.can_read().await {
-                        break;
-                    }
-                    let audio = reader.read().await.unwrap();
-                    if let Some(audio) = audio {
-                        match audio {
-                            SynthesizedResponse::AudioBytes(_) => {
-                                println!("read bytes")
-                            }
-                            SynthesizedResponse::AudioMetadata(_) => {
-                                println!("read metadata")
-                            }
-                        }
-                    } else {
-                        println!("read None");
-                    }
+            loop {
+                if signal.load(Ordering::Relaxed) && !reader.can_read().await {
+                    break;
                 }
-                println!("{:?}", Instant::now() - start)
+                let audio = reader.read().await.unwrap();
+                if let Some(audio) = audio {
+                    match audio {
+                        SynthesizedResponse::AudioBytes(_) => {
+                            println!("read bytes")
+                        }
+                        SynthesizedResponse::AudioMetadata(_) => {
+                            println!("read metadata")
+                        }
+                    }
+                } else {
+                    println!("read None");
+                }
             }
+            println!("{:?}", Instant::now() - start)
         }
-    });
+    }
 }

--- a/examples/synthesize_stream_proxy_async.rs
+++ b/examples/synthesize_stream_proxy_async.rs
@@ -1,57 +1,55 @@
-use futures_util::{AsyncRead, AsyncWrite};
-use msedge_tts::{
-    tts::{
-        stream::{msedge_tts_split_proxy_async, ReaderAsync, SenderAsync, SynthesizedResponse},
-        SpeechConfig,
+use {
+    msedge_tts::{
+        tts::{
+            SpeechConfig,
+            stream::{ReaderAsync, SenderAsync, SynthesizedResponse, msedge_tts_split_proxy_async},
+        },
+        voice::get_voices_list_async,
     },
-    voice::get_voices_list_async,
-};
-use std::{
-    sync::{
-        atomic::{AtomicBool, Ordering},
-        Arc,
+    std::{
+        sync::{
+            Arc,
+            atomic::{AtomicBool, Ordering},
+        },
+        time::Instant,
     },
-    time::Instant,
+    tokio::io::{AsyncRead, AsyncWrite},
 };
 
-fn main() {
-    smol::block_on(async {
-        println!("get voices list...");
-        let voices = get_voices_list_async().await.unwrap();
-        for voice in &voices {
-            if voice.name.contains("YunyangNeural") {
-                println!("choose '{}' to synthesize...", voice.name);
-                let config = Arc::new(SpeechConfig::from(voice));
-                let (sender, reader) = msedge_tts_split_proxy_async(
-                    "http://127.0.0.1:10809".parse().unwrap(),
-                    None,
-                    None,
-                )
-                .await
-                .unwrap();
-                synthesize(sender, reader, config.clone()).await;
+#[tokio::main]
+async fn main() {
+    println!("get voices list...");
+    let voices = get_voices_list_async().await.unwrap();
+    for voice in &voices {
+        if voice.name.contains("YunyangNeural") {
+            println!("choose '{}' to synthesize...", voice.name);
+            let config = Arc::new(SpeechConfig::from(voice));
+            let (sender, reader) =
+                msedge_tts_split_proxy_async("http://127.0.0.1:10809".parse().unwrap(), None, None)
+                    .await
+                    .unwrap();
+            synthesize(sender, reader, config.clone()).await;
 
-                let (sender, reader) = msedge_tts_split_proxy_async(
-                    "socks4a://127.0.0.1:10808".parse().unwrap(),
-                    None,
-                    None,
-                )
-                .await
-                .unwrap();
-                synthesize(sender, reader, config.clone()).await;
+            let (sender, reader) = msedge_tts_split_proxy_async(
+                "socks4a://127.0.0.1:10808".parse().unwrap(),
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+            synthesize(sender, reader, config.clone()).await;
 
-                let (sender, reader) = msedge_tts_split_proxy_async(
-                    "socks5h://127.0.0.1:10808".parse().unwrap(),
-                    None,
-                    None,
-                )
-                .await
-                .unwrap();
-                synthesize(sender, reader, config.clone()).await;
-                break;
-            }
+            let (sender, reader) = msedge_tts_split_proxy_async(
+                "socks5h://127.0.0.1:10808".parse().unwrap(),
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+            synthesize(sender, reader, config.clone()).await;
+            break;
         }
-    });
+    }
 }
 
 async fn synthesize<T: AsyncRead + AsyncWrite + Unpin + Send + Sync + 'static>(
@@ -62,7 +60,7 @@ async fn synthesize<T: AsyncRead + AsyncWrite + Unpin + Send + Sync + 'static>(
     let signal = Arc::new(AtomicBool::new(false));
     let end = signal.clone();
     let start = Instant::now();
-    smol::spawn(async move {
+    tokio::spawn(async move {
         sender
             .send("Hello, World! 你好，世界！", &config)
             .await
@@ -84,8 +82,7 @@ async fn synthesize<T: AsyncRead + AsyncWrite + Unpin + Send + Sync + 'static>(
             .unwrap();
         println!("synthesizing...4");
         end.store(true, Ordering::Relaxed);
-    })
-    .detach();
+    });
 
     loop {
         if signal.load(Ordering::Relaxed) && !reader.can_read().await {

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,14 +4,15 @@ use thiserror::Error;
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
+//noinspection SpellCheckingInspection
 #[derive(Error, Debug)]
 pub enum Error {
     #[error("unexpected message: {0}")]
     UnexpectedMessage(String),
-    #[error("isahc error: {0}")]
-    IsahcError(#[from] isahc::Error),
+    #[error("reqwest error: {0}")]
+    ReqwestError(#[from] reqwest::Error),
     #[error("tungstenite error: {0}")]
-    TungsteniteError(#[from] tungstenite::Error),
+    TungsteniteError(#[from] tokio_tungstenite::tungstenite::Error),
     #[error("serde json error: {0}")]
     SerdeJsonError(#[from] serde_json::Error),
     #[error("proxy error: {0}")]
@@ -41,7 +42,7 @@ pub enum HttpProxyError {
     #[error("io error: {0}")]
     IoError(#[from] std::io::Error),
     #[error("native tls error: {0}")]
-    NativeTlsError(#[from] native_tls::Error),
+    NativeTlsError(#[from] tokio_native_tls::native_tls::Error),
     #[error("invalid response: {0}")]
     InvalidResponse(#[from] httparse::Error),
     #[error("bad response: {0} {1}")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //!     
 //!     fn main() {
 //!         let voices = get_voices_list().unwrap();
-//!         let speechConfig = SpeechConfig::from(&voices[0]);
+//!         let speech_config = SpeechConfig::from(&voices[0]);
 //!     }
 //!     ```
 //!     You can also create [SpeechConfig](tts::SpeechConfig) by yourself. Make sure you know the right **voice name** and **audio format**.
@@ -46,21 +46,20 @@
 //!     ```rust
 //!     use msedge_tts::{tts::client::connect_async, tts::SpeechConfig, voice::get_voices_list_async};
 //!     
-//!     fn main() {
-//!         smol::block_on(async {
-//!             let voices = get_voices_list_async().await.unwrap();
-//!             for voice in &voices {
-//!                 if voice.name.contains("YunyangNeural") {
-//!                     let config = SpeechConfig::from(voice);
-//!                     let mut tts = connect_async().await.unwrap();
-//!                     let audio = tts
-//!                         .synthesize("Hello, World! 你好，世界！", &config)
-//!                         .await
-//!                         .unwrap();
-//!                     break;
-//!                 }
+//!     #[tokio::main]
+//!     async fn main() {
+//!         let voices = get_voices_list_async().await.unwrap();
+//!         for voice in &voices {
+//!             if voice.name.contains("YunyangNeural") {
+//!                 let config = SpeechConfig::from(voice);
+//!                 let mut tts = connect_async().await.unwrap();
+//!                 let audio = tts
+//!                     .synthesize("Hello, World! 你好，世界！", &config)
+//!                     .await
+//!                    .unwrap();
+//!                 break;
 //!             }
-//!         });
+//!         }
 //!     }
 //!     ```
 //!     ### Sync Stream
@@ -145,63 +144,61 @@
 //!             Arc,
 //!         },
 //!     };
-//!     
-//!     fn main() {
-//!         smol::block_on(async {
-//!             let voices = get_voices_list_async().await.unwrap();
-//!             for voice in &voices {
-//!                 if voice.name.contains("YunyangNeural") {
-//!                     let config = SpeechConfig::from(voice);
-//!                     let (mut sender, mut reader) = msedge_tts_split_async().await.unwrap();
-//!     
-//!                     let signal = Arc::new(AtomicBool::new(false));
-//!                     let end = signal.clone();
-//!                     smol::spawn(async move {
-//!                         sender
-//!                             .send("Hello, World! 你好，世界！", &config)
-//!                             .await
-//!                             .unwrap();
-//!                         println!("synthesizing...1");
-//!                         sender
-//!                             .send("Hello, World! 你好，世界！", &config)
-//!                             .await
-//!                             .unwrap();
-//!                         println!("synthesizing...2");
-//!                         sender
-//!                             .send("Hello, World! 你好，世界！", &config)
-//!                             .await
-//!                             .unwrap();
-//!                         println!("synthesizing...3");
-//!                         sender
-//!                             .send("Hello, World! 你好，世界！", &config)
-//!                             .await
-//!                             .unwrap();
-//!                         println!("synthesizing...4");
-//!                         end.store(true, Ordering::Relaxed);
-//!                     })
-//!                     .detach();
-//!     
-//!                     loop {
-//!                         if signal.load(Ordering::Relaxed) && !reader.can_read().await {
-//!                             break;
-//!                         }
-//!                         let audio = reader.read().await.unwrap();
-//!                         if let Some(audio) = audio {
-//!                             match audio {
-//!                                 SynthesizedResponse::AudioBytes(_) => {
-//!                                     println!("read bytes")
-//!                                 }
-//!                                 SynthesizedResponse::AudioMetadata(_) => {
-//!                                     println!("read metadata")
-//!                                 }
+//!
+//!     #[tokio::main]
+//!     async fn main() {
+//!         let voices = get_voices_list_async().await.unwrap();
+//!         for voice in &voices {
+//!             if voice.name.contains("YunyangNeural") {
+//!                 let config = SpeechConfig::from(voice);
+//!                 let (mut sender, mut reader) = msedge_tts_split_async().await.unwrap();
+//!
+//!                 let signal = Arc::new(AtomicBool::new(false));
+//!                 let end = signal.clone();
+//!                 tokio::spawn(async move {
+//!                     sender
+//!                         .send("Hello, World! 你好，世界！", &config)
+//!                         .await
+//!                         .unwrap();
+//!                     println!("synthesizing...1");
+//!                     sender
+//!                         .send("Hello, World! 你好，世界！", &config)
+//!                         .await
+//!                         .unwrap();
+//!                     println!("synthesizing...2");
+//!                     sender
+//!                         .send("Hello, World! 你好，世界！", &config)
+//!                         .await
+//!                         .unwrap();
+//!                     println!("synthesizing...3");
+//!                     sender
+//!                         .send("Hello, World! 你好，世界！", &config)
+//!                         .await
+//!                         .unwrap();
+//!                     println!("synthesizing...4");
+//!                     end.store(true, Ordering::Relaxed);
+//!                 });
+//!
+//!                 loop {
+//!                     if signal.load(Ordering::Relaxed) && !reader.can_read().await {
+//!                         break;
+//!                     }
+//!                     let audio = reader.read().await.unwrap();
+//!                     if let Some(audio) = audio {
+//!                         match audio {
+//!                             SynthesizedResponse::AudioBytes(_) => {
+//!                                 println!("read bytes")
 //!                             }
-//!                         } else {
-//!                             println!("read None");
+//!                             SynthesizedResponse::AudioMetadata(_) => {
+//!                                 println!("read metadata")
+//!                             }
 //!                         }
+//!                     } else {
+//!                         println!("read None");
 //!                     }
 //!                 }
 //!             }
-//!         });
+//!         }
 //!     }
 //!     ```
 


### PR DESCRIPTION
Use reqwest library instead of isahc library (fixes compilation issue in #10).

- Migrate from async-std to tokio and update dependencies
- Replace async-std with tokio for async runtime
- Update dependencies including tungstenite to tokio-tungstenite
- Add blocking feature and examples
- Improve error handling and proxy support